### PR TITLE
Add end-to-end Chatterbox audio rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ rclaw create "top 3 features" --template social-clip
 # Create with custom props
 rclaw create "weekly stats" --template data-viz --props '{"data":[10,25,40,35,50],"labels":["W1","W2","W3","W4","W5"]}'
 
-# Create with TTS voiceover
+# Create with TTS voiceover (auto-matches video length to audio)
 rclaw create "product overview" --tts "Welcome to our product demo. Let me show you what we've built."
+
+# Create with local Chatterbox voice cloning
+rclaw create "weekly update" --tts "Here’s what we shipped this week." --tts-provider chatterbox
 
 # Render a specific composition
 rclaw render SocialClip -o out/clip.mp4 --width 1080 --height 1920
@@ -102,18 +105,23 @@ All templates accept props as inline JSON (`--props '{...}'`) or from a file (`-
 
 ## TTS
 
-Generate voiceover audio with OpenAI or ElevenLabs:
+Generate voiceover audio with Chatterbox (default, local voice clone), OpenAI, or ElevenLabs:
 
 ```bash
+# Chatterbox local TTS (default, no API key)
+rclaw tts "Your script here"
+
 # OpenAI TTS (requires OPENAI_API_KEY)
 rclaw tts "Your script here" --provider openai --voice alloy
 
 # ElevenLabs (requires ELEVENLABS_API_KEY)
 rclaw tts "Your script here" --provider elevenlabs --voice <voice-id>
 
-# Create video with inline TTS
+# Create video with inline TTS (audio is embedded into the MP4)
 rclaw create "demo" --tts "Welcome to our product walkthrough"
 ```
+
+When `--tts` is used and `--duration` is omitted, `rclaw create` auto-detects the generated audio length and sizes the video to match.
 
 ## Programmatic Usage
 

--- a/bin/rclaw.js
+++ b/bin/rclaw.js
@@ -34,7 +34,7 @@ program
   .option('-o, --output <path>', 'Output file path', 'out/video.mp4')
   .option('--props <json>', 'JSON props to pass to the composition')
   .option('--props-file <path>', 'Path to JSON props file')
-  .option('--duration <seconds>', 'Video duration in seconds', '30')
+  .option('--duration <seconds>', 'Video duration in seconds')
   .option('--tts <text>', 'Generate TTS voiceover from text')
   .option('--tts-provider <provider>', 'TTS provider: chatterbox (default), openai, elevenlabs', 'chatterbox')
   .option('--voice <voice>', 'TTS voice name (openai/elevenlabs)', 'auto')

--- a/src/commands/create.js
+++ b/src/commands/create.js
@@ -1,9 +1,11 @@
 import { execSync } from 'child_process';
-import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync, copyFileSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { getTemplate, TEMPLATES } from '../utils/templates.js';
 import { resolveProps } from '../utils/resolve-props.js';
+import { buildCreateProps } from '../utils/create-default-props.js';
 import { generateTTS } from '../tts/generate.js';
+import { getAudioDuration } from '../utils/audio.js';
 
 /**
  * Infer template from natural language description.
@@ -22,38 +24,34 @@ function inferTemplate(description) {
   if (d.includes('product') || d.includes('demo') || d.includes('app') || d.includes('feature') || d.includes('walkthrough')) {
     return 'product-demo';
   }
-  // Default to announcement for simple text-based videos
   return 'announcement';
 }
 
 export async function createCommand(description, options) {
-  // Determine template
   const templateName = options.template || inferTemplate(description);
   const template = getTemplate(templateName);
 
   console.log(`\n🎬 Creating video: "${description}"`);
   console.log(`📐 Template: ${template.name} (${template.width}x${template.height})`);
 
-  // Resolve props
+  // Resolve props from CLI and apply template-specific defaults
   let props = resolveProps(options);
-  props = {
-    ...props,
-    title: props.title || description,
-    description: props.description || description,
-  };
+  props = buildCreateProps(templateName, description, props, options);
 
-  // Calculate duration
-  const durationSec = parseInt(options.duration || '30', 10);
   const fps = parseInt(options.fps || template.fps.toString(), 10);
-  const durationInFrames = durationSec * fps;
 
-  // Handle TTS
+  // ── TTS Pipeline ──────────────────────────────────
   let audioPath = null;
+  let audioDurationSec = 0;
+
   if (options.tts) {
     const ttsProvider = options.ttsProvider || 'chatterbox';
     const ext = ttsProvider === 'chatterbox' ? '.wav' : '.mp3';
-    console.log(`🔊 Generating TTS voiceover...`);
-    audioPath = resolve(dirname(options.output), `voiceover${ext}`);
+    const output = options.output || 'out/video.mp4';
+
+    console.log(`\n🔊 Generating TTS voiceover...`);
+    audioPath = resolve(dirname(output), `voiceover${ext}`);
+
     await generateTTS(options.tts, {
       output: audioPath,
       provider: ttsProvider,
@@ -62,20 +60,48 @@ export async function createCommand(description, options) {
       exaggeration: options.exaggeration ? parseFloat(options.exaggeration) : undefined,
       cfgWeight: options.cfgWeight ? parseFloat(options.cfgWeight) : undefined,
     });
-    props.audioSrc = audioPath;
-    console.log(`✅ TTS saved: ${audioPath}`);
+
+    // Detect audio duration and auto-size video
+    audioDurationSec = getAudioDuration(audioPath);
+    console.log(`✅ TTS saved: ${audioPath} (${audioDurationSec.toFixed(1)}s)`);
+
+    // Copy audio to public/ so Remotion can serve it via staticFile()
+    const publicDir = resolve(dirname(template.entryPoint), '..', '..', 'public');
+    if (!existsSync(publicDir)) mkdirSync(publicDir, { recursive: true });
+    const audioFilename = `voiceover-${Date.now()}${audioPath.match(/\.[^.]+$/)?.[0] || '.wav'}`;
+    copyFileSync(audioPath, resolve(publicDir, audioFilename));
+    props.audioSrc = audioFilename;
+    console.log(`📁 Audio staged: public/${audioFilename}`);
   }
 
-  // Set up output
+  // ── Duration Calculation ──────────────────────────
+  // Priority: explicit --duration > audio duration + padding > template default
+  let durationSec;
+  if (options.duration) {
+    durationSec = parseInt(options.duration, 10);
+  } else if (audioDurationSec > 0) {
+    // Add 2s padding (1s lead-in + 1s fade-out)
+    durationSec = Math.ceil(audioDurationSec) + 2;
+    console.log(`⏱️  Auto-duration: ${durationSec}s (audio ${audioDurationSec.toFixed(1)}s + 2s padding)`);
+  } else {
+    durationSec = Math.ceil(template.durationInFrames / fps);
+  }
+
+  const durationInFrames = durationSec * fps;
+
+  // ── Output Setup ──────────────────────────────────
   const output = options.output || 'out/video.mp4';
   const outDir = dirname(output);
   if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 
-  // Write props file
+  // Pass duration to Remotion template via props
+  props.durationInFrames = durationInFrames;
+
+  // Write props file for Remotion
   const propsFile = resolve(outDir, '.rclaw-props.json');
   writeFileSync(propsFile, JSON.stringify(props, null, 2));
 
-  // Build render command
+  // ── Render ────────────────────────────────────────
   const width = options.width || template.width;
   const height = options.height || template.height;
 
@@ -91,7 +117,8 @@ export async function createCommand(description, options) {
   ];
 
   const cmd = args.join(' ');
-  console.log(`\n🎥 Render command: ${cmd}\n`);
+  console.log(`\n🎥 Rendering ${durationSec}s video (${durationInFrames} frames @ ${fps}fps)...`);
+  console.log(`   Command: ${cmd}\n`);
 
   try {
     execSync(cmd, { stdio: 'inherit' });

--- a/src/utils/audio.js
+++ b/src/utils/audio.js
@@ -1,0 +1,63 @@
+import { execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+
+/**
+ * Get duration of an audio file in seconds using ffprobe.
+ * Falls back to a rough WAV header calculation if ffprobe isn't available.
+ *
+ * @param {string} audioPath - Path to audio file
+ * @returns {number} Duration in seconds
+ */
+export function getAudioDuration(audioPath) {
+  if (!existsSync(audioPath)) {
+    throw new Error(`Audio file not found: ${audioPath}`);
+  }
+
+  try {
+    // Try ffprobe first (most accurate)
+    const result = execSync(
+      `ffprobe -v quiet -show_entries format=duration -of csv=p=0 "${audioPath}"`,
+      { encoding: 'utf8', timeout: 10000 }
+    ).trim();
+    const duration = parseFloat(result);
+    if (!isNaN(duration) && duration > 0) return duration;
+  } catch {
+    // ffprobe not available, try soxi
+    try {
+      const result = execSync(`soxi -D "${audioPath}"`, {
+        encoding: 'utf8',
+        timeout: 10000,
+      }).trim();
+      const duration = parseFloat(result);
+      if (!isNaN(duration) && duration > 0) return duration;
+    } catch {
+      // Fall back to WAV header parsing
+      if (audioPath.endsWith('.wav')) {
+        return getWavDuration(audioPath);
+      }
+    }
+  }
+
+  // Default: assume 10 seconds
+  console.warn('⚠️  Could not detect audio duration, defaulting to 10s');
+  return 10;
+}
+
+/**
+ * Parse WAV header for duration.
+ */
+function getWavDuration(wavPath) {
+  const buf = readFileSync(wavPath);
+
+  // WAV header: bytes 24-27 = sample rate, bytes 28-31 = byte rate
+  if (buf.length < 44) return 10;
+
+  const sampleRate = buf.readUInt32LE(24);
+  const byteRate = buf.readUInt32LE(28);
+
+  if (byteRate === 0) return 10;
+
+  // Data size = file size - 44 (header)
+  const dataSize = buf.length - 44;
+  return dataSize / byteRate;
+}

--- a/src/utils/create-default-props.js
+++ b/src/utils/create-default-props.js
@@ -1,0 +1,44 @@
+/**
+ * Fill template-specific default props for `rclaw create`.
+ * Keeps natural-language create flows usable without requiring explicit JSON props.
+ */
+export function buildCreateProps(templateName, description, baseProps = {}, options = {}) {
+  const ttsText = options.tts || '';
+
+  switch (templateName) {
+    case 'announcement':
+      return {
+        ...baseProps,
+        title: baseProps.title || description,
+        body: baseProps.body || ttsText || description,
+      };
+
+    case 'social-clip':
+      return {
+        ...baseProps,
+        title: baseProps.title || description,
+        subtitle: baseProps.subtitle || ttsText || description,
+      };
+
+    case 'data-viz':
+      return {
+        ...baseProps,
+        title: baseProps.title || description,
+        subtitle: baseProps.subtitle || ttsText || '',
+      };
+
+    case 'product-demo':
+      return {
+        ...baseProps,
+        title: baseProps.title || description,
+        tagline: baseProps.tagline || ttsText || description,
+      };
+
+    default:
+      return {
+        ...baseProps,
+        title: baseProps.title || description,
+        description: baseProps.description || ttsText || description,
+      };
+  }
+}

--- a/templates/announcement/Announcement.jsx
+++ b/templates/announcement/Announcement.jsx
@@ -6,6 +6,7 @@ import {
   interpolate,
   spring,
 } from "remotion";
+import { AudioOverlay } from "../shared/AudioOverlay.jsx";
 
 export const Announcement = ({
   title = "Big News!",
@@ -14,6 +15,8 @@ export const Announcement = ({
   background = "#16213e",
   textColor = "#ffffff",
   author = "",
+  audioSrc = null,
+  audioVolume = 1,
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
@@ -51,6 +54,7 @@ export const Announcement = ({
         opacity: fadeOut,
       }}
     >
+      <AudioOverlay audioSrc={audioSrc} volume={audioVolume} />
       {/* Background decoration */}
       <div
         style={{

--- a/templates/announcement/Root.jsx
+++ b/templates/announcement/Root.jsx
@@ -5,7 +5,7 @@ export const AnnouncementRoot = () => (
   <Composition
     id="Announcement"
     component={Announcement}
-    durationInFrames={150}
+    durationInFrames={900}
     fps={30}
     width={1080}
     height={1080}
@@ -15,6 +15,13 @@ export const AnnouncementRoot = () => (
       accent: "#e94560",
       background: "#16213e",
       textColor: "#ffffff",
+    }}
+    calculateMetadata={async ({ props }) => {
+      // Allow dynamic duration override via props
+      if (props.durationInFrames) {
+        return { durationInFrames: props.durationInFrames };
+      }
+      return {};
     }}
   />
 );

--- a/templates/data-viz/DataViz.jsx
+++ b/templates/data-viz/DataViz.jsx
@@ -6,6 +6,7 @@ import {
   interpolate,
   spring,
 } from "remotion";
+import { AudioOverlay } from "../shared/AudioOverlay.jsx";
 
 export const DataViz = ({
   title = "Data Overview",
@@ -15,6 +16,8 @@ export const DataViz = ({
   background = "#0f0f23",
   textColor = "#ffffff",
   subtitle = "",
+  audioSrc = null,
+  audioVolume = 1,
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
@@ -42,6 +45,7 @@ export const DataViz = ({
         padding: 80,
       }}
     >
+      <AudioOverlay audioSrc={audioSrc} volume={audioVolume} />
       {/* Title */}
       <h1
         style={{

--- a/templates/data-viz/Root.jsx
+++ b/templates/data-viz/Root.jsx
@@ -17,5 +17,11 @@ export const DataVizRoot = () => (
       background: "#0f0f23",
       textColor: "#ffffff",
     }}
+    calculateMetadata={async ({ props }) => {
+      if (props.durationInFrames) {
+        return { durationInFrames: props.durationInFrames };
+      }
+      return {};
+    }}
   />
 );

--- a/templates/product-demo/ProductDemo.jsx
+++ b/templates/product-demo/ProductDemo.jsx
@@ -7,6 +7,7 @@ import {
   spring,
   Sequence,
 } from "remotion";
+import { AudioOverlay } from "../shared/AudioOverlay.jsx";
 
 export const ProductDemo = ({
   title = "Product Name",
@@ -16,6 +17,8 @@ export const ProductDemo = ({
   accentColor = "#7c3aed",
   textColor = "#ffffff",
   screenshotUrl = "",
+  audioSrc = null,
+  audioVolume = 1,
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
@@ -32,6 +35,7 @@ export const ProductDemo = ({
 
   return (
     <AbsoluteFill style={{ background, opacity: fadeOut }}>
+      <AudioOverlay audioSrc={audioSrc} volume={audioVolume} />
       {/* Gradient background */}
       <AbsoluteFill
         style={{

--- a/templates/product-demo/Root.jsx
+++ b/templates/product-demo/Root.jsx
@@ -17,5 +17,11 @@ export const ProductDemoRoot = () => (
       accentColor: "#7c3aed",
       textColor: "#ffffff",
     }}
+    calculateMetadata={async ({ props }) => {
+      if (props.durationInFrames) {
+        return { durationInFrames: props.durationInFrames };
+      }
+      return {};
+    }}
   />
 );

--- a/templates/shared/AudioOverlay.jsx
+++ b/templates/shared/AudioOverlay.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Audio, staticFile } from "remotion";
+
+/**
+ * Shared audio overlay component.
+ * Audio files must be in the public/ folder or passed as staticFile names.
+ *
+ * Props:
+ *   audioSrc — filename in public/ folder (e.g., "voiceover.wav")
+ *   volume — 0-1 (default 1)
+ */
+export const AudioOverlay = ({ audioSrc, volume = 1 }) => {
+  if (!audioSrc) return null;
+
+  // Use staticFile for public/ folder files
+  const src = staticFile(audioSrc);
+
+  return <Audio src={src} volume={volume} />;
+};

--- a/templates/social-clip/Root.jsx
+++ b/templates/social-clip/Root.jsx
@@ -16,5 +16,11 @@ export const SocialClipRoot = () => (
       accentColor: "#e94560",
       textColor: "#ffffff",
     }}
+    calculateMetadata={async ({ props }) => {
+      if (props.durationInFrames) {
+        return { durationInFrames: props.durationInFrames };
+      }
+      return {};
+    }}
   />
 );

--- a/templates/social-clip/SocialClip.jsx
+++ b/templates/social-clip/SocialClip.jsx
@@ -7,6 +7,7 @@ import {
   spring,
   Sequence,
 } from "remotion";
+import { AudioOverlay } from "../shared/AudioOverlay.jsx";
 
 export const SocialClip = ({
   title = "Your Title",
@@ -15,6 +16,8 @@ export const SocialClip = ({
   accentColor = "#e94560",
   textColor = "#ffffff",
   items = [],
+  audioSrc = null,
+  audioVolume = 1,
 }) => {
   const frame = useCurrentFrame();
   const { fps, durationInFrames } = useVideoConfig();
@@ -45,6 +48,7 @@ export const SocialClip = ({
         opacity: fadeOut,
       }}
     >
+      <AudioOverlay audioSrc={audioSrc} volume={audioVolume} />
       {/* Background gradient overlay */}
       <AbsoluteFill
         style={{


### PR DESCRIPTION
## Summary
- add end-to-end audio support for `rclaw create --tts`
- stage generated audio into `public/` so Remotion can bundle it
- auto-size video duration to the generated audio when `--duration` is omitted
- add template-specific default prop mapping for natural-language `create` flows
- update README to document Chatterbox-first TTS behavior

## What changed
- added shared `AudioOverlay` component and wired all templates to accept `audioSrc`
- added audio duration helper with WAV fallback support
- removed the default `--duration 30` override from the CLI so auto-duration can work
- fixed create defaults for announcement/social/data-viz/product-demo templates

## Validation
- `node bin/rclaw.js list`
- `node bin/rclaw.js create "OpenClaw v3 announcement" --tts "OpenClaw just shipped version three. The agent fleet is fully operational. Time to build." -o out/pr-smoke.mp4`
- verified output with `ffprobe` → MP4 contains both video and audio streams

## Notes
- local OpenClaw remotion skill docs were also updated to match the new behavior
